### PR TITLE
[no-jira] Set target ruby version in rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.6.0
 Layout/LineLength:
   Max: 250
 Metrics/MethodLength:

--- a/lib/app_size_report/plugin.rb
+++ b/lib/app_size_report/plugin.rb
@@ -247,7 +247,7 @@ module Danger
     private
 
     def create_temp_dir(temp_path)
-      Dir.mkdir $temp_path
+      Dir.mkdir temp_path
     end
 
     def clean_temp!(temp_path)

--- a/lib/app_size_report/plugin.rb
+++ b/lib/app_size_report/plugin.rb
@@ -247,7 +247,7 @@ module Danger
     private
 
     def create_temp_dir(temp_path)
-      Dir.mkdir temp_path
+      Dir.mkdir $temp_path
     end
 
     def clean_temp!(temp_path)


### PR DESCRIPTION
**Change Description**
1. Set target ruby version to 2.6.0 in rubocop configuration.

**Test Plan/Testing Performed**
1. This PR is to test the Bitrise PR workflow.