### PR TITLE
[IMA-12176] Added 'limit_size' argument for iOS and Android

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ Metrics/BlockLength:
 Metrics/PerceivedComplexity:
   Max: 20
 Metrics/CyclomaticComplexity:
-  Max: 15
+  Max: 20
 Metrics/AbcSize:
   Max: 70
 Metrics/ClassLength:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-app_size_report (0.0.4)
+    danger-app_size_report (1.0.0)
       danger-plugin-api (~> 1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The list of variants with their sizes and any violations will be displayed in th
 - `report_path` [String, required] Path to valid App Thinning Size Report text file.
 - `build_type` [String, optional] [Default: 'App'] Specify whether the report corresponds to an App or an App Clip.
   - Supported values: 'App', 'Clip'
-- `limit_size` [Numeric, optional] [Default: 4] Specify the app size limit.
+- `limit_size` [Numeric, optional] [Default: 4] Specify the app size limit. If the build type is set to 'Clip' and the specified app size limit exceeds 10 MB, the 10 MB limit will be enforced to meet Apple's App Clip size requirements.
 - `limit_unit` [String, optional] [Default: 'GB'] Specific the unit for the given size limit.
   - Supported values: 'KB', 'MB', 'GB'
 - `fail_on_warning` [Boolean, optional] [Default: false] Specify whether the PR should fail if one or more app variants exceed the given size limit. By default, the plugin issues a warning in this case.
@@ -94,7 +94,7 @@ The top 25 violations will be displayed in the PR report with any remaining viol
 - `languages` [Array, optional] [Default: ["en"]] Array of languages to check APK size
 - `build_type` [String, optional] [Default: 'App'] Specify whether the report corresponds to an App or an Instant.
   - Supported values: 'App', 'Instant'
-- `limit_size` [Numeric, optional] [Default: 150] Specify the app size limit.
+- `limit_size` [Numeric, optional] [Default: 150] Specify the app size limit. If the build type is set to 'Instant' and the specified app size limit exceeds 4 MB, the 4 MB limit will be enforced to meet Android Instant App size requirements.
 - `limit_unit` [String, optional] [Default: 'MB'] Specific the unit for the given size limit.
   - Supported values: 'KB', 'MB', 'GB'
 - `fail_on_warning` [Boolean, optional] [Default: false] Specify whether the PR should fail if one or more app variants exceed the given size limit. By default, the plugin issues a warning in this case.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Report **iOS** app size violations given a valid App Thinning Size Report. A val
     app_size_report.flag_ios_violations(
         report_path,
         build_type: 'App',
-        size_limit: 4,
+        limit_size: 4,
         limit_unit: 'GB',
         fail_on_warning: false
     )
@@ -34,7 +34,7 @@ The list of variants with their sizes and any violations will be displayed in th
 - `report_path` [String, required] Path to valid App Thinning Size Report text file.
 - `build_type` [String, optional] [Default: 'App'] Specify whether the report corresponds to an App or an App Clip.
   - Supported values: 'App', 'Clip'
-- `size_limit` [Numeric, optional] [Default: 4] Specify the app size limit.
+- `limit_size` [Numeric, optional] [Default: 4] Specify the app size limit.
 - `limit_unit` [String, optional] [Default: 'GB'] Specific the unit for the given size limit.
   - Supported values: 'KB', 'MB', 'GB'
 - `fail_on_warning` [Boolean, optional] [Default: false] Specify whether the PR should fail if one or more app variants exceed the given size limit. By default, the plugin issues a warning in this case.
@@ -72,7 +72,7 @@ Report <b>Android</b> app size violations given a valid Android App Bundle (AAB)
         screen_densities: ["MDPI", "HDPI", "XHDPI", "XXHDPI", "XXXHDPI"],
         languages: ["en", "de", "da", "es", "fr", "it", "nb", "nl", "sv"],
         build_type: 'Instant',
-        size_limit: 4,
+        limit_size: 4,
         limit_unit: 'MB',
         fail_on_warning: false
     )
@@ -94,7 +94,7 @@ The top 25 violations will be displayed in the PR report with any remaining viol
 - `languages` [Array, optional] [Default: ["en"]] Array of languages to check APK size
 - `build_type` [String, optional] [Default: 'App'] Specify whether the report corresponds to an App or an Instant.
   - Supported values: 'App', 'Instant'
-- `size_limit` [Numeric, optional] [Default: 150] Specify the app size limit.
+- `limit_size` [Numeric, optional] [Default: 150] Specify the app size limit.
 - `limit_unit` [String, optional] [Default: 'MB'] Specific the unit for the given size limit.
   - Supported values: 'KB', 'MB', 'GB'
 - `fail_on_warning` [Boolean, optional] [Default: false] Specify whether the PR should fail if one or more app variants exceed the given size limit. By default, the plugin issues a warning in this case.

--- a/lib/app_size_report/plugin.rb
+++ b/lib/app_size_report/plugin.rb
@@ -129,8 +129,8 @@ module Danger
     #         Default: 'App'
     #         Supported values: 'App', 'Clip'
     #   @param [Numeric, optional] limit_size
-    #         Specify the app size limit. If the build type is set to 'Clip' and the 
-    #         specified app size limit exceeds 10 MB, the 10 MB limit will be enforced 
+    #         Specify the app size limit. If the build type is set to 'Clip' and the
+    #         specified app size limit exceeds 10 MB, the 10 MB limit will be enforced
     #         to meet Apple's App Clip size requirements.
     #         Default: 4
     #   @param [String, optional] limit_unit
@@ -204,8 +204,8 @@ module Danger
     #         Default: 'App'
     #         Supported values: 'App', 'Instant'
     #   @param [Numeric, optional] limit_size
-    #         Specify the app size limit. If the build type is set to 'Instant' and the 
-    #         specified app size limit exceeds 4 MB, the 4 MB limit will be enforced to 
+    #         Specify the app size limit. If the build type is set to 'Instant' and the
+    #         specified app size limit exceeds 4 MB, the 4 MB limit will be enforced to
     #         meet Android Instant App size requirements.
     #         Default: 150
     #   @param [String, optional] limit_unit

--- a/lib/app_size_report/plugin.rb
+++ b/lib/app_size_report/plugin.rb
@@ -129,7 +129,9 @@ module Danger
     #         Default: 'App'
     #         Supported values: 'App', 'Clip'
     #   @param [Numeric, optional] limit_size
-    #         Specify the app size limit.
+    #         Specify the app size limit. If the build type is set to 'Clip' and the 
+    #         specified app size limit exceeds 10 MB, the 10 MB limit will be enforced 
+    #         to meet Apple's App Clip size requirements.
     #         Default: 4
     #   @param [String, optional] limit_unit
     #         Specific the unit for the given size limit.
@@ -186,23 +188,25 @@ module Danger
     #   @param [String, required] ks_path
     #         Path to valid signing key file.
     #   @param [String, required] ks_alias
-    #         Alias of signing key
+    #         Alias of signing key.
     #   @param [String, required] ks_password
-    #         Password of signing key
+    #         Password of signing key.
     #   @param [String, required] ks_alias_password
     #         Alias Password of signing key.
     #   @param [Array, optional] screen_densities
-    #         Array of screen densities to check APK size
+    #         Array of screen densities to check APK size.
     #         Default: ["MDPI", "HDPI", "XHDPI", "XXHDPI", "XXXHDPI"]
     #   @param [Array, optional] languages
-    #         Array of languages to check APK size
+    #         Array of languages to check APK size.
     #         Default: ["en"]
     #   @param [String, optional] build_type
     #         Specify whether the report corresponds to an App, Instant.
     #         Default: 'App'
     #         Supported values: 'App', 'Instant'
     #   @param [Numeric, optional] limit_size
-    #         Specify the app size limit.
+    #         Specify the app size limit. If the build type is set to 'Instant' and the 
+    #         specified app size limit exceeds 4 MB, the 4 MB limit will be enforced to 
+    #         meet Android Instant App size requirements.
     #         Default: 150
     #   @param [String, optional] limit_unit
     #         Specific the unit for the given size limit.

--- a/lib/converter/models/app_size_model.rb
+++ b/lib/converter/models/app_size_model.rb
@@ -2,8 +2,8 @@
 
 require_relative '../helper/json_converter'
 
-# App Size Model
-# @example 'App size: 6.6 MB compressed, 12.9 MB uncompressed'
+# App Size Model.
+# Example: 'App size: 6.6 MB compressed, 12.9 MB uncompressed'
 class AppSizeModel < JSONConverter
   attr_reader :compressed, :uncompressed
 

--- a/lib/converter/models/device_model.rb
+++ b/lib/converter/models/device_model.rb
@@ -2,8 +2,8 @@
 
 require_relative '../helper/json_converter'
 
-# Device Model
-# @example 'device: iPhone10,3, os-version: 14.0'
+# Device Model.
+# Example: 'device: iPhone10,3, os-version: 14.0'
 class DeviceModel < JSONConverter
   attr_reader :device, :os_version
 

--- a/lib/converter/parser/variant_parser.rb
+++ b/lib/converter/parser/variant_parser.rb
@@ -2,8 +2,8 @@
 
 require_relative './model_parser'
 
-# Parse Variant section of App Thinning Size Report
-# @example 'Variant: ChargePointAppClip-35AD0331-EA57-4B82-B8E6-029D7786B9B7.ipa'
+# Parse Variant section of App Thinning Size Report.
+# Example: 'Variant: ChargePointAppClip-35AD0331-EA57-4B82-B8E6-029D7786B9B7.ipa'
 class VariantParser < ModelParser
   def parse
     @text = @text.strip

--- a/spec/app_size_report_spec.rb
+++ b/spec/app_size_report_spec.rb
@@ -26,7 +26,7 @@ module Danger
         @app_size_report.flag_ios_violations(
           "#{File.dirname(__dir__)}/Resources/App\ Thinning\ Size\ Report.txt",
           build_type: 'Clip',
-          size_limit: 12,
+          limit_size: 12,
           limit_unit: 'MB'
         )
 
@@ -43,7 +43,7 @@ module Danger
           screen_densities: %w[MDPI HDPI XHDPI XXHDPI XXXHDPI],
           languages: %w[en de da es fr it nb nl sv],
           build_type: 'Instant',
-          size_limit: 1.459,
+          limit_size: 1.459,
           limit_unit: 'MB'
         )
 


### PR DESCRIPTION
**Change Description**
1. Added new 'limit_size' argument for both `flag_ios_violations` and `flag_android_violations`.
2. Moved to using the ruby **kargs form of arguments for our optional keyword arguments. This takes the arguments in as a hash and allows us to check if an argument has been passed or not. This was needed as we need to maintain backward compatibility with the old 'size_limit' argument. 
3. Updated yard documentation for methods.
4. Increased cyclomatic complexity max value to 20 in the Rubocop styling config.
5. Updated README.md to provide a more elaborate explanation of the default value used for 'limit_size' when the build type is 'Clip' or 'Instant'.

**Test Plan/Testing Performed**
1. Ran unit tests successfully.